### PR TITLE
Improve cross-account role handling

### DIFF
--- a/iam.tf
+++ b/iam.tf
@@ -1,7 +1,7 @@
 
 resource "aws_iam_role" "github_actions" {
   name               = "github-actions"
-  assume_role_policy = merge(data.aws_iam_policy_document.github_oidc_assume_role.json, additional_roles)
+  assume_role_policy = data.aws_iam_policy_document.github_oidc_assume_role.json
 }
 
 data "aws_iam_policy_document" "github_oidc_assume_role" {
@@ -28,16 +28,6 @@ data "aws_iam_policy_document" "github_oidc_assume_role" {
       test     = "StringLike"
       variable = "token.actions.githubusercontent.com:sub"
       values   = ["repo:${var.github_repository}"]
-    }
-  }
-
-  statement {
-    sid     = "AllowOIDCToAssumeRoles"
-    effect  = "Allow"
-    actions = ["sts:AssumeRole"]
-    principals {
-      type        = "AWS"
-      identifiers = [var.additional_roles]
     }
   }
 }

--- a/iam.tf
+++ b/iam.tf
@@ -43,3 +43,8 @@ resource "aws_iam_policy" "extra_permissions" {
 
   policy = var.additional_permissions
 }
+
+resource "aws_iam_role_policy_attachment" "extra_permissions" {
+  role       = aws_iam_role.github_actions.name
+  policy_arn = aws_iam_policy.extra_permissions.arn
+}

--- a/test/unit-test/main.tf
+++ b/test/unit-test/main.tf
@@ -8,6 +8,10 @@ module "module_test" {
 }
 
 data "aws_iam_policy_document" "extra_permissions" {
+  #checkov:skip=CKV_AWS_107
+  #checkov:skip=CKV_AWS_108
+  #checkov:skip=CKV_AWS_109
+  #checkov:skip=CKV_AWS_111
   version = "2012-10-17"
 
   statement {

--- a/variables.tf
+++ b/variables.tf
@@ -8,10 +8,6 @@ variable "additional_permissions" {
   description = "accept aws_iam_policy_document with additional permissions to attach to the github-actions role"
 }
 
-variable "additional_roles" {
-  description = "additional role ARNs to be assumed"
-}
-
 ## Tags / Prefix
 variable "tags_common" {
   description = "MOJ required tags"

--- a/variables.tf
+++ b/variables.tf
@@ -8,6 +8,10 @@ variable "additional_permissions" {
   description = "accept aws_iam_policy_document with additional permissions to attach to the github-actions role"
 }
 
+variable "additional_roles" {
+  description = "additional role ARNs to be assumed"
+}
+
 ## Tags / Prefix
 variable "tags_common" {
   description = "MOJ required tags"


### PR DESCRIPTION
* Correctly map `additional_permissions` to a role as this was missing
* Insert extra roles to be assumed directly into policy document as a variable