### PR TITLE
Refactor OIDC Module

### DIFF
--- a/README.md
+++ b/README.md
@@ -82,4 +82,5 @@ No modules.
 |------|-------------|
 | <a name="output_github_actions_provider"></a> [github\_actions\_provider](#output\_github\_actions\_provider) | This module configures an OIDC provider for use with GitHub actions |
 | <a name="output_github_actions_role"></a> [github\_actions\_role](#output\_github\_actions\_role) | IAM Role created for use by the OIDC provider |
+| <a name="output_github_actions_role_trust_policy"></a> [github\_actions\_role\_trust\_policy](#output\_github\_actions\_role\_trust\_policy) | Assume role policy for the github-actions role |
 <!-- END_TF_DOCS -->

--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@ and the associated IAM resources required to make use of the connect provider.
 module "github-oidc-provider" {
 
   source                 = "https://github.com/ministryofjustice/modernisation-platform-terraform-github-oidc-provider"
-  github_repository      = "ministryofjustice/your-repository-name:*"
+  github_repositories    = ["ministryofjustice/your-repository-name:*"]
   additional_permissions = data.aws_iam_policy_document.extra_permissions.json
   tags_common            = local.tags
   tags_prefix            = terraform.workspace
@@ -33,20 +33,20 @@ an `aws_iam_policy_document` data call.
 If you're looking to raise an issue with this module, please create a new issue in the [Modernisation Platform repository](https://github.com/ministryofjustice/modernisation-platform/issues).
 
 <!-- BEGIN_TF_DOCS -->
-
 ## Requirements
 
-| Name                                                                     | Version  |
-| ------------------------------------------------------------------------ | -------- |
-| <a name="requirement_terraform"></a> [terraform](#requirement_terraform) | >= 1.0.1 |
-| <a name="requirement_aws"></a> [aws](#requirement_aws)                   | ~> 4.0   |
+| Name | Version |
+|------|---------|
+| <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | >= 1.0.1 |
+| <a name="requirement_aws"></a> [aws](#requirement\_aws) | ~> 4.0 |
+| <a name="requirement_tls"></a> [tls](#requirement\_tls) | ~> 4.0 |
 
 ## Providers
 
-| Name                                             | Version |
-| ------------------------------------------------ | ------- |
-| <a name="provider_aws"></a> [aws](#provider_aws) | ~> 4.0  |
-| <a name="provider_tls"></a> [tls](#provider_tls) | n/a     |
+| Name | Version |
+|------|---------|
+| <a name="provider_aws"></a> [aws](#provider\_aws) | ~> 4.0 |
+| <a name="provider_tls"></a> [tls](#provider\_tls) | ~> 4.0 |
 
 ## Modules
 
@@ -54,33 +54,32 @@ No modules.
 
 ## Resources
 
-| Name                                                                                                                                                                 | Type        |
-| -------------------------------------------------------------------------------------------------------------------------------------------------------------------- | ----------- |
-| [aws_iam_openid_connect_provider.github_actions](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/iam_openid_connect_provider)            | resource    |
-| [aws_iam_policy.extra_permissions](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/iam_policy)                                           | resource    |
-| [aws_iam_role.github_actions](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/iam_role)                                                  | resource    |
-| [aws_iam_role_policy_attachment.additional_managed_policies](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/iam_role_policy_attachment) | resource    |
-| [aws_iam_role_policy_attachment.extra_permissions](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/iam_role_policy_attachment)           | resource    |
-| [aws_iam_role_policy_attachment.read_only](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/iam_role_policy_attachment)                   | resource    |
-| [aws_caller_identity.current](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/caller_identity)                                        | data source |
-| [aws_iam_policy_document.github_oidc_assume_role](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/iam_policy_document)                | data source |
-| [tls_certificate.github](https://registry.terraform.io/providers/hashicorp/tls/latest/docs/data-sources/certificate)                                                 | data source |
+| Name | Type |
+|------|------|
+| [aws_iam_openid_connect_provider.github_actions](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/iam_openid_connect_provider) | resource |
+| [aws_iam_policy.extra_permissions](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/iam_policy) | resource |
+| [aws_iam_role.github_actions](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/iam_role) | resource |
+| [aws_iam_role_policy_attachment.additional_managed_policies](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/iam_role_policy_attachment) | resource |
+| [aws_iam_role_policy_attachment.extra_permissions](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/iam_role_policy_attachment) | resource |
+| [aws_iam_role_policy_attachment.read_only](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/iam_role_policy_attachment) | resource |
+| [aws_caller_identity.current](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/caller_identity) | data source |
+| [aws_iam_policy_document.github_oidc_assume_role](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/iam_policy_document) | data source |
+| [tls_certificate.github](https://registry.terraform.io/providers/hashicorp/tls/latest/docs/data-sources/certificate) | data source |
 
 ## Inputs
 
-| Name                                                                                                               | Description                                                                                     | Type           | Default | Required |
-| ------------------------------------------------------------------------------------------------------------------ | ----------------------------------------------------------------------------------------------- | -------------- | ------- | :------: |
-| <a name="input_additional_managed_policies"></a> [additional_managed_policies](#input_additional_managed_policies) | accept a list of arns for aws managed policies to attach to github-actions role                 | `list(string)` | `[]`    |    no    |
-| <a name="input_additional_permissions"></a> [additional_permissions](#input_additional_permissions)                | accept aws_iam_policy_document with additional permissions to attach to the github-actions role | `string`       | n/a     |   yes    |
-| <a name="input_github_repository"></a> [github_repository](#input_github_repository)                               | The github repository, for example ministryofjustice/modernisation-platform-environments:\*     | `string`       | n/a     |   yes    |
-| <a name="input_tags_common"></a> [tags_common](#input_tags_common)                                                 | MOJ required tags                                                                               | `map(string)`  | n/a     |   yes    |
-| <a name="input_tags_prefix"></a> [tags_prefix](#input_tags_prefix)                                                 | prefix for name tags                                                                            | `string`       | n/a     |   yes    |
+| Name | Description | Type | Default | Required |
+|------|-------------|------|---------|:--------:|
+| <a name="input_additional_managed_policies"></a> [additional\_managed\_policies](#input\_additional\_managed\_policies) | accept a list of arns for aws managed policies to attach to github-actions role | `list(string)` | `[]` | no |
+| <a name="input_additional_permissions"></a> [additional\_permissions](#input\_additional\_permissions) | accept aws\_iam\_policy\_document with additional permissions to attach to the github-actions role | `string` | n/a | yes |
+| <a name="input_github_repositories"></a> [github\_repositories](#input\_github\_repositories) | The github repositories, for example ["ministryofjustice/modernisation-platform-environments:*"] | `list(string)` | n/a | yes |
+| <a name="input_tags_common"></a> [tags\_common](#input\_tags\_common) | MOJ required tags | `map(string)` | n/a | yes |
+| <a name="input_tags_prefix"></a> [tags\_prefix](#input\_tags\_prefix) | prefix for name tags | `string` | n/a | yes |
 
 ## Outputs
 
-| Name                                                                                                     | Description                                                         |
-| -------------------------------------------------------------------------------------------------------- | ------------------------------------------------------------------- |
-| <a name="output_github_actions_provider"></a> [github_actions_provider](#output_github_actions_provider) | This module configures an OIDC provider for use with GitHub actions |
-| <a name="output_github_actions_role"></a> [github_actions_role](#output_github_actions_role)             | IAM Role created for use by the OIDC provider                       |
-
+| Name | Description |
+|------|-------------|
+| <a name="output_github_actions_provider"></a> [github\_actions\_provider](#output\_github\_actions\_provider) | This module configures an OIDC provider for use with GitHub actions |
+| <a name="output_github_actions_role"></a> [github\_actions\_role](#output\_github\_actions\_role) | IAM Role created for use by the OIDC provider |
 <!-- END_TF_DOCS -->

--- a/README.md
+++ b/README.md
@@ -33,20 +33,21 @@ an `aws_iam_policy_document` data call.
 If you're looking to raise an issue with this module, please create a new issue in the [Modernisation Platform repository](https://github.com/ministryofjustice/modernisation-platform/issues).
 
 <!-- BEGIN_TF_DOCS -->
+
 ## Requirements
 
-| Name | Version |
-|------|---------|
-| <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | >= 1.0.1 |
-| <a name="requirement_aws"></a> [aws](#requirement\_aws) | ~> 4.0 |
-| <a name="requirement_tls"></a> [tls](#requirement\_tls) | ~> 4.0 |
+| Name                                                                     | Version  |
+| ------------------------------------------------------------------------ | -------- |
+| <a name="requirement_terraform"></a> [terraform](#requirement_terraform) | >= 1.0.1 |
+| <a name="requirement_aws"></a> [aws](#requirement_aws)                   | ~> 4.0   |
+| <a name="requirement_tls"></a> [tls](#requirement_tls)                   | ~> 4.0   |
 
 ## Providers
 
-| Name | Version |
-|------|---------|
-| <a name="provider_aws"></a> [aws](#provider\_aws) | ~> 4.0 |
-| <a name="provider_tls"></a> [tls](#provider\_tls) | ~> 4.0 |
+| Name                                             | Version |
+| ------------------------------------------------ | ------- |
+| <a name="provider_aws"></a> [aws](#provider_aws) | ~> 4.0  |
+| <a name="provider_tls"></a> [tls](#provider_tls) | ~> 4.0  |
 
 ## Modules
 
@@ -54,33 +55,34 @@ No modules.
 
 ## Resources
 
-| Name | Type |
-|------|------|
-| [aws_iam_openid_connect_provider.github_actions](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/iam_openid_connect_provider) | resource |
-| [aws_iam_policy.extra_permissions](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/iam_policy) | resource |
-| [aws_iam_role.github_actions](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/iam_role) | resource |
-| [aws_iam_role_policy_attachment.additional_managed_policies](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/iam_role_policy_attachment) | resource |
-| [aws_iam_role_policy_attachment.extra_permissions](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/iam_role_policy_attachment) | resource |
-| [aws_iam_role_policy_attachment.read_only](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/iam_role_policy_attachment) | resource |
-| [aws_caller_identity.current](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/caller_identity) | data source |
-| [aws_iam_policy_document.github_oidc_assume_role](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/iam_policy_document) | data source |
-| [tls_certificate.github](https://registry.terraform.io/providers/hashicorp/tls/latest/docs/data-sources/certificate) | data source |
+| Name                                                                                                                                                                 | Type        |
+| -------------------------------------------------------------------------------------------------------------------------------------------------------------------- | ----------- |
+| [aws_iam_openid_connect_provider.github_actions](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/iam_openid_connect_provider)            | resource    |
+| [aws_iam_policy.extra_permissions](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/iam_policy)                                           | resource    |
+| [aws_iam_role.github_actions](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/iam_role)                                                  | resource    |
+| [aws_iam_role_policy_attachment.additional_managed_policies](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/iam_role_policy_attachment) | resource    |
+| [aws_iam_role_policy_attachment.extra_permissions](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/iam_role_policy_attachment)           | resource    |
+| [aws_iam_role_policy_attachment.read_only](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/iam_role_policy_attachment)                   | resource    |
+| [aws_caller_identity.current](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/caller_identity)                                        | data source |
+| [aws_iam_policy_document.github_oidc_assume_role](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/iam_policy_document)                | data source |
+| [tls_certificate.github](https://registry.terraform.io/providers/hashicorp/tls/latest/docs/data-sources/certificate)                                                 | data source |
 
 ## Inputs
 
-| Name | Description | Type | Default | Required |
-|------|-------------|------|---------|:--------:|
-| <a name="input_additional_managed_policies"></a> [additional\_managed\_policies](#input\_additional\_managed\_policies) | accept a list of arns for aws managed policies to attach to github-actions role | `list(string)` | `[]` | no |
-| <a name="input_additional_permissions"></a> [additional\_permissions](#input\_additional\_permissions) | accept aws\_iam\_policy\_document with additional permissions to attach to the github-actions role | `string` | n/a | yes |
-| <a name="input_github_repositories"></a> [github\_repositories](#input\_github\_repositories) | The github repositories, for example ["ministryofjustice/modernisation-platform-environments:*"] | `list(string)` | n/a | yes |
-| <a name="input_tags_common"></a> [tags\_common](#input\_tags\_common) | MOJ required tags | `map(string)` | n/a | yes |
-| <a name="input_tags_prefix"></a> [tags\_prefix](#input\_tags\_prefix) | prefix for name tags | `string` | n/a | yes |
+| Name                                                                                                               | Description                                                                                      | Type           | Default | Required |
+| ------------------------------------------------------------------------------------------------------------------ | ------------------------------------------------------------------------------------------------ | -------------- | ------- | :------: |
+| <a name="input_additional_managed_policies"></a> [additional_managed_policies](#input_additional_managed_policies) | accept a list of arns for aws managed policies to attach to github-actions role                  | `list(string)` | `[]`    |    no    |
+| <a name="input_additional_permissions"></a> [additional_permissions](#input_additional_permissions)                | accept aws_iam_policy_document with additional permissions to attach to the github-actions role  | `string`       | n/a     |   yes    |
+| <a name="input_github_repositories"></a> [github_repositories](#input_github_repositories)                         | The github repositories, for example ["ministryofjustice/modernisation-platform-environments:*"] | `list(string)` | n/a     |   yes    |
+| <a name="input_tags_common"></a> [tags_common](#input_tags_common)                                                 | MOJ required tags                                                                                | `map(string)`  | n/a     |   yes    |
+| <a name="input_tags_prefix"></a> [tags_prefix](#input_tags_prefix)                                                 | prefix for name tags                                                                             | `string`       | n/a     |   yes    |
 
 ## Outputs
 
-| Name | Description |
-|------|-------------|
-| <a name="output_github_actions_provider"></a> [github\_actions\_provider](#output\_github\_actions\_provider) | This module configures an OIDC provider for use with GitHub actions |
-| <a name="output_github_actions_role"></a> [github\_actions\_role](#output\_github\_actions\_role) | IAM Role created for use by the OIDC provider |
-| <a name="output_github_actions_role_trust_policy"></a> [github\_actions\_role\_trust\_policy](#output\_github\_actions\_role\_trust\_policy) | Assume role policy for the github-actions role |
+| Name                                                                                                                                | Description                                                         |
+| ----------------------------------------------------------------------------------------------------------------------------------- | ------------------------------------------------------------------- |
+| <a name="output_github_actions_provider"></a> [github_actions_provider](#output_github_actions_provider)                            | This module configures an OIDC provider for use with GitHub actions |
+| <a name="output_github_actions_role"></a> [github_actions_role](#output_github_actions_role)                                        | IAM Role created for use by the OIDC provider                       |
+| <a name="output_github_actions_role_trust_policy"></a> [github_actions_role_trust_policy](#output_github_actions_role_trust_policy) | Assume role policy for the github-actions role                      |
+
 <!-- END_TF_DOCS -->

--- a/iam.tf
+++ b/iam.tf
@@ -27,7 +27,7 @@ data "aws_iam_policy_document" "github_oidc_assume_role" {
     condition {
       test     = "StringLike"
       variable = "token.actions.githubusercontent.com:sub"
-      values   = ["repo:${var.github_repository}"]
+      values   = formatlist("repo:%s", var.github_repositories)
     }
   }
 }

--- a/outputs.tf
+++ b/outputs.tf
@@ -7,3 +7,8 @@ output "github_actions_role" {
   description = "IAM Role created for use by the OIDC provider"
   value       = aws_iam_role.github_actions.arn
 }
+
+output "github_actions_role_trust_policy" {
+  description = "Assume role policy for the github-actions role"
+  value       = data.aws_iam_policy_document.github_oidc_assume_role.json
+}

--- a/test/module_test.go
+++ b/test/module_test.go
@@ -1,10 +1,11 @@
 package main
 
 import (
-	"github.com/gruntwork-io/terratest/modules/terraform"
-	"github.com/stretchr/testify/assert"
 	"regexp"
 	"testing"
+
+	"github.com/gruntwork-io/terratest/modules/terraform"
+	"github.com/stretchr/testify/assert"
 )
 
 func TestGitHubOIDCProviderCreation(t *testing.T) {
@@ -16,7 +17,10 @@ func TestGitHubOIDCProviderCreation(t *testing.T) {
 
 	defer terraform.Destroy(t, terraformOptions)
 
-	terraform.InitAndApply(t, terraformOptions)
+	terraform.Init(t, terraformOptions)
+	terraform.WorkspaceSelectOrNew(t, terraformOptions, "testing-test")
+
+	terraform.Apply(t, terraformOptions)
 
 	github_actions_provider := terraform.Output(t, terraformOptions, "github_actions_provider")
 

--- a/test/module_test.go
+++ b/test/module_test.go
@@ -6,6 +6,7 @@ import (
 
 	"github.com/gruntwork-io/terratest/modules/terraform"
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 )
 
 func TestGitHubOIDCProviderCreation(t *testing.T) {
@@ -23,6 +24,8 @@ func TestGitHubOIDCProviderCreation(t *testing.T) {
 	terraform.Apply(t, terraformOptions)
 
 	github_actions_provider := terraform.Output(t, terraformOptions, "github_actions_provider")
+	github_actions_role_trust_policy_conditions := terraform.Output(t, terraformOptions, "github_actions_trust_policy_conditions")
 
 	assert.Regexp(t, regexp.MustCompile(`^arn:aws:iam::\d{12}:oidc-provider/token.actions.githubusercontent.com`), github_actions_provider)
+	require.Equal(t, github_actions_role_trust_policy_conditions, "[map[token.actions.githubusercontent.com:sub:[repo:ministryofjustice/modernisation-platform-environments:* repo:ministryofjustice/modernisation-platform-ami-builds:*]]]")
 }

--- a/test/unit-test/main.tf
+++ b/test/unit-test/main.tf
@@ -1,7 +1,7 @@
 
 module "module_test" {
   source                 = "../../"
-  github_repository      = "ministryofjustice/modernisation-platform-environments:*"
+  github_repositories    = ["ministryofjustice/modernisation-platform-environments:*", "ministryofjustice/modernisation-platform-ami-builds:*"]
   additional_permissions = data.aws_iam_policy_document.extra_permissions.json
   tags_common            = local.tags
   tags_prefix            = terraform.workspace

--- a/test/unit-test/outputs.tf
+++ b/test/unit-test/outputs.tf
@@ -1,3 +1,7 @@
 output "github_actions_provider" {
   value = module.module_test.github_actions_provider
 }
+
+output "github_actions_trust_policy_conditions" {
+  value = jsondecode(module.module_test.github_actions_role_trust_policy).Statement[*].Condition.StringLike
+}

--- a/test/unit-test/providers.tf
+++ b/test/unit-test/providers.tf
@@ -1,7 +1,7 @@
 provider "aws" {
   region = "eu-west-2"
   assume_role {
-    role_arn = "arn:aws:iam::${local.environment_management.account_ids["testing-test"]}:role/ModernisationPlatformAccess"
+    role_arn = "arn:aws:iam::${local.environment_management.account_ids[terraform.workspace]}:role/ModernisationPlatformAccess"
   }
 }
 

--- a/variables.tf
+++ b/variables.tf
@@ -1,6 +1,11 @@
-variable "github_repository" {
-  type        = string
-  description = "The github repository, for example ministryofjustice/modernisation-platform-environments:*"
+variable "github_repositories" {
+  type        = list(string)
+  description = "The github repositories, for example [\"ministryofjustice/modernisation-platform-environments:*\"]"
+  validation {
+    condition     = length(var.github_repositories) > 0
+    error_message = "At least one repository must be specified."
+  }
+
 }
 
 variable "additional_permissions" {


### PR DESCRIPTION
This PR makes two changes to the OIDC module:

* It replaces `github-repository` string variable with `github-repositories` list(string) variable to allow the use of github-actions role in multiple repos.

This is a breaking change!

Additionally

* module_test.go is modified to expicitly select `testing-test` workspace before running an apply so that the correct state file is used when running tests.
