### PR TITLE
Adding option to specify OIDC role name.

### DIFF
--- a/.github/workflows/documentation.yml
+++ b/.github/workflows/documentation.yml
@@ -7,9 +7,11 @@ on:
     paths:
       - '**.md'
       - '.github/workflows/documentation.yml'
-
+permissions: {}
 jobs:
   docs:
+    permissions:
+      contents: write
     runs-on: ubuntu-latest
     steps:
     - uses: actions/checkout@ac593985615ec2ede58e132d2e21d2b1cbd6127c # v3.3.0

--- a/.github/workflows/go-terratest.yml
+++ b/.github/workflows/go-terratest.yml
@@ -1,12 +1,16 @@
 on:
   pull_request:
     types: [opened, edited, reopened, synchronize]
+permissions: {}
 env:
   AWS_ACCESS_KEY_ID:  ${{ secrets.AWS_ACCESS_KEY_ID }}
   AWS_SECRET_ACCESS_KEY:  ${{ secrets.AWS_SECRET_ACCESS_KEY }}
   TF_IN_AUTOMATION: true
 jobs:
   go-tests:
+    permissions:
+      contents: read
+      actions: write
     name: Run Go Unit Tests
     runs-on: ubuntu-latest
     steps:

--- a/README.md
+++ b/README.md
@@ -33,5 +33,55 @@ an `aws_iam_policy_document` data call.
 If you're looking to raise an issue with this module, please create a new issue in the [Modernisation Platform repository](https://github.com/ministryofjustice/modernisation-platform/issues).
 
 <!-- BEGIN_TF_DOCS -->
+## Requirements
 
+| Name | Version |
+|------|---------|
+| <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | >= 1.0.1 |
+| <a name="requirement_aws"></a> [aws](#requirement\_aws) | ~> 4.0 |
+| <a name="requirement_tls"></a> [tls](#requirement\_tls) | ~> 4.0 |
+
+## Providers
+
+| Name | Version |
+|------|---------|
+| <a name="provider_aws"></a> [aws](#provider\_aws) | ~> 4.0 |
+| <a name="provider_tls"></a> [tls](#provider\_tls) | ~> 4.0 |
+
+## Modules
+
+No modules.
+
+## Resources
+
+| Name | Type |
+|------|------|
+| [aws_iam_openid_connect_provider.github_actions](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/iam_openid_connect_provider) | resource |
+| [aws_iam_policy.extra_permissions](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/iam_policy) | resource |
+| [aws_iam_role.github_actions](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/iam_role) | resource |
+| [aws_iam_role_policy_attachment.additional_managed_policies](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/iam_role_policy_attachment) | resource |
+| [aws_iam_role_policy_attachment.extra_permissions](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/iam_role_policy_attachment) | resource |
+| [aws_iam_role_policy_attachment.read_only](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/iam_role_policy_attachment) | resource |
+| [aws_caller_identity.current](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/caller_identity) | data source |
+| [aws_iam_policy_document.github_oidc_assume_role](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/iam_policy_document) | data source |
+| [tls_certificate.github](https://registry.terraform.io/providers/hashicorp/tls/latest/docs/data-sources/certificate) | data source |
+
+## Inputs
+
+| Name | Description | Type | Default | Required |
+|------|-------------|------|---------|:--------:|
+| <a name="input_additional_managed_policies"></a> [additional\_managed\_policies](#input\_additional\_managed\_policies) | accept a list of arns for aws managed policies to attach to OIDC-provider role | `list(string)` | `[]` | no |
+| <a name="input_additional_permissions"></a> [additional\_permissions](#input\_additional\_permissions) | accept aws\_iam\_policy\_document with additional permissions to attach to the OIDC-provider role | `string` | n/a | yes |
+| <a name="input_github_repositories"></a> [github\_repositories](#input\_github\_repositories) | The github repositories, for example ["ministryofjustice/modernisation-platform-environments:*"] | `list(string)` | n/a | yes |
+| <a name="input_role_name"></a> [role\_name](#input\_role\_name) | OIDC Role Name | `string` | `"github-actions"` | no |
+| <a name="input_tags_common"></a> [tags\_common](#input\_tags\_common) | MOJ required tags | `map(string)` | n/a | yes |
+| <a name="input_tags_prefix"></a> [tags\_prefix](#input\_tags\_prefix) | prefix for name tags | `string` | n/a | yes |
+
+## Outputs
+
+| Name | Description |
+|------|-------------|
+| <a name="output_github_actions_provider"></a> [github\_actions\_provider](#output\_github\_actions\_provider) | This module configures an OIDC provider for use with GitHub actions |
+| <a name="output_github_actions_role"></a> [github\_actions\_role](#output\_github\_actions\_role) | IAM Role created for use by the OIDC provider |
+| <a name="output_github_actions_role_trust_policy"></a> [github\_actions\_role\_trust\_policy](#output\_github\_actions\_role\_trust\_policy) | Assume role policy for the github-actions role |
 <!-- END_TF_DOCS -->

--- a/README.md
+++ b/README.md
@@ -33,54 +33,5 @@ an `aws_iam_policy_document` data call.
 If you're looking to raise an issue with this module, please create a new issue in the [Modernisation Platform repository](https://github.com/ministryofjustice/modernisation-platform/issues).
 
 <!-- BEGIN_TF_DOCS -->
-## Requirements
 
-| Name | Version |
-|------|---------|
-| <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | >= 1.0.1 |
-| <a name="requirement_aws"></a> [aws](#requirement\_aws) | ~> 4.0 |
-| <a name="requirement_tls"></a> [tls](#requirement\_tls) | ~> 4.0 |
-
-## Providers
-
-| Name | Version |
-|------|---------|
-| <a name="provider_aws"></a> [aws](#provider\_aws) | ~> 4.0 |
-| <a name="provider_tls"></a> [tls](#provider\_tls) | ~> 4.0 |
-
-## Modules
-
-No modules.
-
-## Resources
-
-| Name | Type |
-|------|------|
-| [aws_iam_openid_connect_provider.github_actions](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/iam_openid_connect_provider) | resource |
-| [aws_iam_policy.extra_permissions](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/iam_policy) | resource |
-| [aws_iam_role.github_actions](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/iam_role) | resource |
-| [aws_iam_role_policy_attachment.additional_managed_policies](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/iam_role_policy_attachment) | resource |
-| [aws_iam_role_policy_attachment.extra_permissions](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/iam_role_policy_attachment) | resource |
-| [aws_iam_role_policy_attachment.read_only](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/iam_role_policy_attachment) | resource |
-| [aws_caller_identity.current](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/caller_identity) | data source |
-| [aws_iam_policy_document.github_oidc_assume_role](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/iam_policy_document) | data source |
-| [tls_certificate.github](https://registry.terraform.io/providers/hashicorp/tls/latest/docs/data-sources/certificate) | data source |
-
-## Inputs
-
-| Name | Description | Type | Default | Required |
-|------|-------------|------|---------|:--------:|
-| <a name="input_additional_managed_policies"></a> [additional\_managed\_policies](#input\_additional\_managed\_policies) | accept a list of arns for aws managed policies to attach to github-actions role | `list(string)` | `[]` | no |
-| <a name="input_additional_permissions"></a> [additional\_permissions](#input\_additional\_permissions) | accept aws\_iam\_policy\_document with additional permissions to attach to the github-actions role | `string` | n/a | yes |
-| <a name="input_github_repositories"></a> [github\_repositories](#input\_github\_repositories) | The github repositories, for example ["ministryofjustice/modernisation-platform-environments:*"] | `list(string)` | n/a | yes |
-| <a name="input_tags_common"></a> [tags\_common](#input\_tags\_common) | MOJ required tags | `map(string)` | n/a | yes |
-| <a name="input_tags_prefix"></a> [tags\_prefix](#input\_tags\_prefix) | prefix for name tags | `string` | n/a | yes |
-
-## Outputs
-
-| Name | Description |
-|------|-------------|
-| <a name="output_github_actions_provider"></a> [github\_actions\_provider](#output\_github\_actions\_provider) | This module configures an OIDC provider for use with GitHub actions |
-| <a name="output_github_actions_role"></a> [github\_actions\_role](#output\_github\_actions\_role) | IAM Role created for use by the OIDC provider |
-| <a name="output_github_actions_role_trust_policy"></a> [github\_actions\_role\_trust\_policy](#output\_github\_actions\_role\_trust\_policy) | Assume role policy for the github-actions role |
 <!-- END_TF_DOCS -->

--- a/iam.tf
+++ b/iam.tf
@@ -1,6 +1,6 @@
 
 resource "aws_iam_role" "github_actions" {
-  name               = "github-actions"
+  name               = var.role_name
   assume_role_policy = data.aws_iam_policy_document.github_oidc_assume_role.json
 }
 
@@ -45,7 +45,7 @@ resource "aws_iam_role_policy_attachment" "additional_managed_policies" {
 
 # Add actions missing from arn:aws:iam::aws:policy/ReadOnlyAccess
 resource "aws_iam_policy" "extra_permissions" {
-  name        = "github-actions"
+  name        = var.role_name
   path        = "/"
   description = "A policy for extra permissions for GitHub Actions"
 

--- a/test/module_test.go
+++ b/test/module_test.go
@@ -22,7 +22,12 @@ func TestGitHubOIDCProviderCreation(t *testing.T) {
 
 	github_actions_provider := terraform.Output(t, terraformOptions, "github_actions_provider")
 	github_actions_role_trust_policy_conditions := terraform.Output(t, terraformOptions, "github_actions_trust_policy_conditions")
+	oidc_role_arn := terraform.Output(t, terraformOptions, "oidc_role")
 
 	assert.Regexp(t, regexp.MustCompile(`^arn:aws:iam::\d{12}:oidc-provider/token.actions.githubusercontent.com`), github_actions_provider)
 	require.Equal(t, github_actions_role_trust_policy_conditions, "[map[token.actions.githubusercontent.com:sub:[repo:ministryofjustice/modernisation-platform-environments:* repo:ministryofjustice/modernisation-platform-ami-builds:*]]]")
+
+	// Testing backwards compatibility
+
+	assert.Regexp(t, regexp.MustCompile(`^arn:aws:iam::\d{12}:role/github-actions`), oidc_role_arn)
 }

--- a/test/unit-test/outputs.tf
+++ b/test/unit-test/outputs.tf
@@ -5,3 +5,7 @@ output "github_actions_provider" {
 output "github_actions_trust_policy_conditions" {
   value = jsondecode(module.module_test.github_actions_role_trust_policy).Statement[*].Condition.StringLike
 }
+
+output "oidc_role" {
+  value = module.module_test.github_actions_role
+}

--- a/variables.tf
+++ b/variables.tf
@@ -10,13 +10,20 @@ variable "github_repositories" {
 
 variable "additional_permissions" {
   type        = string
-  description = "accept aws_iam_policy_document with additional permissions to attach to the github-actions role"
+  description = "accept aws_iam_policy_document with additional permissions to attach to the OIDC-provider role"
 }
 
 variable "additional_managed_policies" {
   type        = list(string)
-  description = "accept a list of arns for aws managed policies to attach to github-actions role"
+  description = "accept a list of arns for aws managed policies to attach to OIDC-provider role"
   default     = []
+}
+
+## OIDC Role Name
+variable "role_name" {
+  type        = string
+  description = "OIDC Role Name"
+  default     = "github-actions"
 }
 
 ## Tags / Prefix


### PR DESCRIPTION
If there are no issues with other teams reusing these modules, adding the option of configuring different role names with `github-actions` being default for backward compatibility.
