### PR TITLE
❇️ Add GitHub known TLS thumbprints

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -2,7 +2,7 @@
 # This module configures an OIDC provider for use with GitHub actions.
 resource "aws_iam_openid_connect_provider" "github_actions" {
   client_id_list  = ["sts.amazonaws.com"]
-  thumbprint_list = data.tls_certificate.github.certificates[*].sha1_fingerprint
+  thumbprint_list = distinct(concat(data.tls_certificate.github.certificates[*].sha1_fingerprint, var.github_known_thumbprints))
   url             = "https://token.actions.githubusercontent.com"
   tags            = var.tags_common
 }

--- a/test/unit-test/main.tf
+++ b/test/unit-test/main.tf
@@ -12,7 +12,7 @@ data "aws_iam_policy_document" "extra_permissions" {
   #checkov:skip=CKV_AWS_108
   #checkov:skip=CKV_AWS_109
   #checkov:skip=CKV_AWS_111
-  #checkov:skip=CKV_AWS_356
+  #checkov:skip=CKV_AWS_356 skipping check as this code is used in a unit test, not production
   version = "2012-10-17"
 
   statement {

--- a/test/unit-test/main.tf
+++ b/test/unit-test/main.tf
@@ -12,6 +12,7 @@ data "aws_iam_policy_document" "extra_permissions" {
   #checkov:skip=CKV_AWS_108
   #checkov:skip=CKV_AWS_109
   #checkov:skip=CKV_AWS_111
+  #checkov:skip=CKV_AWS_356
   version = "2012-10-17"
 
   statement {

--- a/variables.tf
+++ b/variables.tf
@@ -1,3 +1,12 @@
+variable "github_known_thumbprints" {
+  type        = list(string)
+  description = "The known intermediary thumbprints for the GitHub OIDC provider"
+  default = [
+    "1c58a3a8518e8759bf075b76b750d4f2df264fcd",
+    "6938fd4d98bab03faadb97b34396831e3780aea1"
+  ]
+}
+
 variable "github_repositories" {
   type        = list(string)
   description = "The github repositories, for example [\"ministryofjustice/modernisation-platform-environments:*\"]"


### PR DESCRIPTION
Seeing continuous updates on `thumbprint_list`

```terraform
~ thumbprint_list = [
  - "6938fd4d98bab03faadb97b34396831e3780aea1",
    "1c58a3a8518e8759bf075b76b750d4f2df264fcd",
  + "f879abce0008e4eb126e0097e46620f5aaae26ad",
  ]
```

https://github.blog/changelog/2023-06-27-github-actions-update-on-oidc-integration-with-aws/