### PR TITLE
Added condition to clear checkov error CKV_AWS_358

### DIFF
--- a/iam.tf
+++ b/iam.tf
@@ -5,6 +5,7 @@ resource "aws_iam_role" "github_actions" {
 }
 
 data "aws_iam_policy_document" "github_oidc_assume_role" {
+  #checkov:skip=CKV_AWS_358 "Skipping as this is controlled by variable validation"
   version = "2012-10-17"
 
   statement {

--- a/iam.tf
+++ b/iam.tf
@@ -29,6 +29,12 @@ data "aws_iam_policy_document" "github_oidc_assume_role" {
       variable = "token.actions.githubusercontent.com:sub"
       values   = formatlist("repo:%s", var.github_repositories)
     }
+    # Addition to clear checkov error
+    condition {
+      test     = "StringLike"
+      variable = "token.actions.githubusercontent.com:sub"
+      values   = "repo:ministryofjustice/*"
+    }
   }
 }
 

--- a/iam.tf
+++ b/iam.tf
@@ -29,11 +29,6 @@ data "aws_iam_policy_document" "github_oidc_assume_role" {
       variable = "token.actions.githubusercontent.com:sub"
       values   = formatlist("repo:%s", var.github_repositories)
     }
-    condition {
-      test     = "StringLike"
-      variable = "token.actions.githubusercontent.com:sub"
-      values   = ["repo:ministryofjustice/*"]
-    }
   }
 }
 

--- a/iam.tf
+++ b/iam.tf
@@ -29,7 +29,6 @@ data "aws_iam_policy_document" "github_oidc_assume_role" {
       variable = "token.actions.githubusercontent.com:sub"
       values   = formatlist("repo:%s", var.github_repositories)
     }
-    # Addition to clear checkov error
     condition {
       test     = "StringLike"
       variable = "token.actions.githubusercontent.com:sub"

--- a/iam.tf
+++ b/iam.tf
@@ -33,7 +33,7 @@ data "aws_iam_policy_document" "github_oidc_assume_role" {
     condition {
       test     = "StringLike"
       variable = "token.actions.githubusercontent.com:sub"
-      values   = "repo:ministryofjustice/*"
+      values   = ["repo:ministryofjustice/*"]
     }
   }
 }

--- a/variables.tf
+++ b/variables.tf
@@ -14,7 +14,13 @@ variable "github_repositories" {
     condition     = length(var.github_repositories) > 0
     error_message = "At least one repository must be specified."
   }
-
+  validation {
+    condition     = alltrue([
+    for repo in var.github_repositories :
+    can(regex("ministryofjustice", repo))
+  ])
+    error_message = "Repository must belong to the \"ministryofjustice\" GitHub organisation"
+  }
 }
 
 variable "additional_permissions" {

--- a/variables.tf
+++ b/variables.tf
@@ -15,10 +15,10 @@ variable "github_repositories" {
     error_message = "At least one repository must be specified."
   }
   validation {
-    condition     = alltrue([
-    for repo in var.github_repositories :
-    can(regex("ministryofjustice", repo))
-  ])
+    condition = alltrue([
+      for repo in var.github_repositories :
+      can(regex("ministryofjustice", repo))
+    ])
     error_message = "Repository must belong to the \"ministryofjustice\" GitHub organisation"
   }
 }


### PR DESCRIPTION
One error in the checkov report to be cleared. The change here should clear the issue. The actual checkov error is CKV_aws_358: "Ensure GitHub Actions OIDC trust policies only allows actions from a specific known organization"

This PR includes a validation for the `github_repositories` variable to give us a combination of flexibility in accepted GitHub Organizations, and control over which Orgs we all. At present, we're only allowing `ministryofjustice` but the conditional validation can be expanded as needed.