### PR TITLE
⚡️Add uniqueness to role name

### DIFF
--- a/test/unit-test/main.tf
+++ b/test/unit-test/main.tf
@@ -1,8 +1,12 @@
+resource "random_id" "role" {
+  byte_length = 1
+}
 
 module "module_test" {
   source                 = "../../"
-  github_repositories    = ["ministryofjustice/modernisation-platform-environments:*", "ministryofjustice/modernisation-platform-ami-builds:*"]
   additional_permissions = data.aws_iam_policy_document.extra_permissions.json
+  github_repositories    = ["ministryofjustice/modernisation-platform-environments:*", "ministryofjustice/modernisation-platform-ami-builds:*"]
+  role_name              = format("github-actions-%s", random_id.role.dec)
   tags_common            = local.tags
   tags_prefix            = terraform.workspace
 }

--- a/test/unit-test/versions.tf
+++ b/test/unit-test/versions.tf
@@ -4,6 +4,10 @@ terraform {
       version = "~> 5.0"
       source  = "hashicorp/aws"
     }
+    random = {
+      source = "hashicorp/random"
+      version = "~> 3.5"
+    }
   }
   required_version = ">= 1.0.1"
 }

--- a/test/unit-test/versions.tf
+++ b/test/unit-test/versions.tf
@@ -5,7 +5,7 @@ terraform {
       source  = "hashicorp/aws"
     }
     random = {
-      source = "hashicorp/random"
+      source  = "hashicorp/random"
       version = "~> 3.5"
     }
   }


### PR DESCRIPTION
Because test runs can sometimes leave behind resources, and these resources are not consistently cleaned up, this PR adds randomness to the `github-actions` role created through unit tests, ensuring that tests will run consistently.