### PR TITLE
added malware protection plan service to the trust policy 

### DIFF
--- a/iam.tf
+++ b/iam.tf
@@ -46,12 +46,6 @@ data "aws_iam_policy_document" "github_oidc_assume_role" {
       variable = "aws:SourceAccount"
       values   = [data.aws_caller_identity.current.account_id]
     }
-
-    condition {
-      test     = "ArnLike"
-      variable = "aws:SourceArn"
-      values   = ["arn:aws:guardduty:eu-west-2:${data.aws_caller_identity.current.account_id}:malware-protection-plan/*"]
-    }
   }
 }
 resource "aws_iam_role_policy_attachment" "read_only" {

--- a/iam.tf
+++ b/iam.tf
@@ -46,6 +46,11 @@ data "aws_iam_policy_document" "github_oidc_assume_role" {
       variable = "aws:SourceAccount"
       values   = [data.aws_caller_identity.current.account_id]
     }
+    condition {
+      test     = "ArnLike"
+      variable = "aws:SourceArn"
+      values   = ["arn:aws:guardduty:eu-west-2:374269020027:malware-protection-plan/*"]
+    }
   }
 }
 resource "aws_iam_role_policy_attachment" "read_only" {

--- a/iam.tf
+++ b/iam.tf
@@ -49,7 +49,7 @@ data "aws_iam_policy_document" "github_oidc_assume_role" {
     condition {
       test     = "ArnLike"
       variable = "aws:SourceArn"
-      values   = ["arn:aws:guardduty:eu-west-2:374269020027:malware-protection-plan/*"]
+      values   = ["arn:aws:guardduty:eu-west-2:${data.aws_caller_identity.current.account_id}:malware-protection-plan/*"]
     }
   }
 }

--- a/iam.tf
+++ b/iam.tf
@@ -31,8 +31,29 @@ data "aws_iam_policy_document" "github_oidc_assume_role" {
       values   = formatlist("repo:%s", var.github_repositories)
     }
   }
-}
+  statement {
+    sid     = "GuardDutyMalwareProtectionForS3"
+    effect  = "Allow"
+    actions = ["sts:AssumeRole"]
 
+    principals {
+      type        = "Service"
+      identifiers = ["malware-protection-plan.guardduty.amazonaws.com"]
+    }
+
+    condition {
+      test     = "StringEquals"
+      variable = "aws:SourceAccount"
+      values   = [data.aws_caller_identity.current.account_id]
+    }
+
+    condition {
+      test     = "ArnLike"
+      variable = "aws:SourceArn"
+      values   = ["arn:aws:guardduty:eu-west-2:${data.aws_caller_identity.current.account_id}:malware-protection-plan/*"]
+    }
+  }
+}
 resource "aws_iam_role_policy_attachment" "read_only" {
   role       = aws_iam_role.github_actions.name
   policy_arn = "arn:aws:iam::aws:policy/ReadOnlyAccess"

--- a/test/module_test.go
+++ b/test/module_test.go
@@ -25,9 +25,13 @@ func TestGitHubOIDCProviderCreation(t *testing.T) {
 	oidc_role_arn := terraform.Output(t, terraformOptions, "oidc_role")
 
 	assert.Regexp(t, regexp.MustCompile(`^arn:aws:iam::\d{12}:oidc-provider/token.actions.githubusercontent.com`), github_actions_provider)
-	require.Equal(t, github_actions_role_trust_policy_conditions, "[map[token.actions.githubusercontent.com:sub:[repo:ministryofjustice/modernisation-platform-environments:* repo:ministryofjustice/modernisation-platform-ami-builds:*]]]")
+
+	// ✅ Check that the GitHub OIDC statement exists in the output
+	require.Contains(t, github_actions_role_trust_policy_conditions, `map[token.actions.githubusercontent.com:sub:[repo:ministryofjustice/modernisation-platform-environments:* repo:ministryofjustice/modernisation-platform-ami-builds:*]]`)
+
+	// ✅ Check that the Malware Protection service statement exists in the output
+	require.Contains(t, github_actions_role_trust_policy_conditions, `map[string_like:<nil>]`)
 
 	// Testing backwards compatibility
-
 	assert.Regexp(t, regexp.MustCompile(`^arn:aws:iam::\d{12}:role/github-actions`), oidc_role_arn)
 }

--- a/test/module_test.go
+++ b/test/module_test.go
@@ -26,10 +26,10 @@ func TestGitHubOIDCProviderCreation(t *testing.T) {
 
 	assert.Regexp(t, regexp.MustCompile(`^arn:aws:iam::\d{12}:oidc-provider/token.actions.githubusercontent.com`), github_actions_provider)
 
-	// ✅ Check that the GitHub OIDC statement exists in the output
+	//  Check that the GitHub OIDC statement exists in the output
 	require.Contains(t, github_actions_role_trust_policy_conditions, `map[token.actions.githubusercontent.com:sub:[repo:ministryofjustice/modernisation-platform-environments:* repo:ministryofjustice/modernisation-platform-ami-builds:*]]`)
 
-	// ✅ Check that the Malware Protection service statement exists in the output
+	// Check that the Malware Protection service statement exists in the output
 	require.Contains(t, github_actions_role_trust_policy_conditions, `map[string_like:<nil>]`)
 
 	// Testing backwards compatibility

--- a/test/unit-test/outputs.tf
+++ b/test/unit-test/outputs.tf
@@ -8,11 +8,6 @@ output "github_actions_trust_policy_conditions" {
     { string_like = try(s.Condition.StringLike, null) }
   ]
 }
-
-
 output "oidc_role" {
   value = module.module_test.github_actions_role
-}
-output "debug_statements" {
-  value = jsondecode(module.module_test.github_actions_role_trust_policy).Statement
 }

--- a/test/unit-test/outputs.tf
+++ b/test/unit-test/outputs.tf
@@ -3,9 +3,16 @@ output "github_actions_provider" {
 }
 
 output "github_actions_trust_policy_conditions" {
-  value = jsondecode(module.module_test.github_actions_role_trust_policy).Statement[*].Condition.StringLike
+  value = [
+    for s in jsondecode(module.module_test.github_actions_role_trust_policy).Statement :
+    { string_like = try(s.Condition.StringLike, null) }
+  ]
 }
+
 
 output "oidc_role" {
   value = module.module_test.github_actions_role
+}
+output "debug_statements" {
+  value = jsondecode(module.module_test.github_actions_role_trust_policy).Statement
 }

--- a/test/unit-test/versions.tf
+++ b/test/unit-test/versions.tf
@@ -8,6 +8,10 @@ terraform {
       source  = "hashicorp/random"
       version = "~> 3.5"
     }
+    http = {
+      source  = "hashicorp/http"
+      version = "~> 3.0"
+    }
   }
   required_version = ">= 1.0.1"
 }


### PR DESCRIPTION
- Allows GuardDuty Malware Protection Plan to assume the `github-actions` role.
- Restricts assumption to only the same AWS account & permissions to only Malware Protection Plan.
- Ensures proper malware scanning functionality for S3.