### PR TITLE
Add try to OIDC provider output to handle cases where the resource is…

### DIFF
--- a/outputs.tf
+++ b/outputs.tf
@@ -1,6 +1,6 @@
 output "github_actions_provider" {
   description = "This module configures an OIDC provider for use with GitHub actions"
-  value       = aws_iam_openid_connect_provider.github_actions[0].id
+  value       = try(aws_iam_openid_connect_provider.github_actions[0].id, null)
 }
 
 output "github_actions_role" {

--- a/test/unit-test/main.tf
+++ b/test/unit-test/main.tf
@@ -2,6 +2,10 @@ resource "random_id" "role" {
   byte_length = 1
 }
 
+resource "random_id_without_provider" "role" {
+  byte_length = 1
+}
+
 module "module_test" {
   source                 = "../../"
   additional_permissions = data.aws_iam_policy_document.extra_permissions.json
@@ -40,7 +44,7 @@ module "module_test_without_provider" {
   source                      = "../../"
   additional_permissions      = data.aws_iam_policy_document.extra_permissions.json
   github_repositories         = ["ministryofjustice/modernisation-platform-environments:*", "ministryofjustice/modernisation-platform-ami-builds:*"]
-  role_name                   = format("github-actions-%s", random_id.role.dec)
+  role_name                   = format("github-actions-%s", random_id_without_provider.role.dec)
   tags_common                 = local.tags
   tags_prefix                 = terraform.workspace
   create_github_oidc_provider = false

--- a/test/unit-test/main.tf
+++ b/test/unit-test/main.tf
@@ -2,7 +2,7 @@ resource "random_id" "role" {
   byte_length = 1
 }
 
-resource "random_id_without_provider" "role" {
+resource "random_id" "role_without_provider" {
   byte_length = 1
 }
 
@@ -44,7 +44,7 @@ module "module_test_without_provider" {
   source                      = "../../"
   additional_permissions      = data.aws_iam_policy_document.extra_permissions.json
   github_repositories         = ["ministryofjustice/modernisation-platform-environments:*", "ministryofjustice/modernisation-platform-ami-builds:*"]
-  role_name                   = format("github-actions-%s", random_id_without_provider.role.dec)
+  role_name                   = format("github-actions-%s", random_id.role_without_provider.dec)
   tags_common                 = local.tags
   tags_prefix                 = terraform.workspace
   create_github_oidc_provider = false

--- a/test/unit-test/main.tf
+++ b/test/unit-test/main.tf
@@ -35,3 +35,38 @@ data "aws_iam_policy_document" "extra_permissions" {
     resources = ["*"]
   }
 }
+
+module "module_test_without_provider" {
+  source                      = "../../"
+  additional_permissions      = data.aws_iam_policy_document.extra_permissions.json
+  github_repositories         = ["ministryofjustice/modernisation-platform-environments:*", "ministryofjustice/modernisation-platform-ami-builds:*"]
+  role_name                   = format("github-actions-%s", random_id.role.dec)
+  tags_common                 = local.tags
+  tags_prefix                 = terraform.workspace
+  create_github_oidc_provider = false
+}
+
+#trivy:ignore:AVD-AWS-0345
+data "aws_iam_policy_document" "extra_permissions" {
+  #checkov:skip=CKV_AWS_107
+  #checkov:skip=CKV_AWS_108
+  #checkov:skip=CKV_AWS_109
+  #checkov:skip=CKV_AWS_111
+  #checkov:skip=CKV_AWS_356 skipping check as this code is used in a unit test, not production
+  version = "2012-10-17"
+
+  statement {
+    effect = "Allow"
+    actions = [
+      "account:GetAlternateContact",
+      "cur:DescribeReportDefinitions",
+      "identitystore:ListGroups",
+      "secretsmanager:GetSecretValue",
+      "sts:AssumeRole",
+      "s3:*",
+      "kms:*",
+    ]
+
+    resources = ["*"]
+  }
+}

--- a/test/unit-test/main.tf
+++ b/test/unit-test/main.tf
@@ -47,7 +47,7 @@ module "module_test_without_provider" {
 }
 
 #trivy:ignore:AVD-AWS-0345
-data "aws_iam_policy_document" "extra_permissions" {
+data "aws_iam_policy_document" "extra_permissions_without_provider" {
   #checkov:skip=CKV_AWS_107
   #checkov:skip=CKV_AWS_108
   #checkov:skip=CKV_AWS_109

--- a/test/unit-test/outputs.tf
+++ b/test/unit-test/outputs.tf
@@ -8,3 +8,14 @@ output "github_actions_trust_policy_conditions" {
 output "oidc_role" {
   value = module.module_test.github_actions_role
 }
+
+output "github_actions_provider_without_provider" {
+  value = module.module_test_without_provider.github_actions_provider
+}
+
+output "github_actions_trust_policy_conditions_without_provider" {
+  value = jsondecode(module.module_test_without_provider.github_actions_role_trust_policy).Statement[*].Condition.StringLike
+}
+output "oidc_role_without_provider" {
+  value = module.module_test_without_provider.github_actions_role
+}


### PR DESCRIPTION
## Issue
https://github.com/ministryofjustice/modernisation-platform/actions/runs/17269959433/job/49011708526#step:13:28
`github_actions_provider` output was not being handled correctly in cases where the provider resource is not being created

## Fix
Added a `try` to OIDC provider output to handle cases where the resource is not being created. Also added extra tests to check the scenario.