### PR TITLE
Use OIDC role in unit tests workflow

### DIFF
--- a/.github/workflows/go-terratest.yml
+++ b/.github/workflows/go-terratest.yml
@@ -51,7 +51,7 @@ jobs:
       - name: Configure AWS credentials (OIDC)
         uses: aws-actions/configure-aws-credentials@8df5847569e6427dd6c4fb1cf565c83acfa8afa7 # v6.0.0
         with:
-          role-to-assume: arn:aws:iam::${{ env.ACCOUNT_NUMBER }}:role/RG-testing-ci-oidc
+          role-to-assume: arn:aws:iam::${{ env.ACCOUNT_NUMBER }}:role/github-actions-testing
           role-session-name: terratest-oidc
           aws-region: eu-west-2
 

--- a/.github/workflows/go-terratest.yml
+++ b/.github/workflows/go-terratest.yml
@@ -21,6 +21,7 @@ jobs:
 
   go-tests:
     permissions:
+      id-token: write
       contents: read
       actions: write
     name: Run Go Unit Tests
@@ -29,13 +30,31 @@ jobs:
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
 
+      # - name: Decrypt Secrets
+      #   uses: ministryofjustice/modernisation-platform-github-actions/decrypt-secrets@5b44b387694dfa249cfa2dcf289ca871abe9e3e2 # v5.0.1
+      #   with:
+      #     testing_ci_iam_user_access_key_id: ${{ needs.fetch-secrets.outputs.testing_ci_iam_user_access_key_id }}
+      #     testing_ci_iam_user_secret_access_key: ${{ needs.fetch-secrets.outputs.testing_ci_iam_user_secret_access_key }}
+      #     PASSPHRASE: ${{ secrets.PASSPHRASE }}
+      
       - name: Decrypt Secrets
         uses: ministryofjustice/modernisation-platform-github-actions/decrypt-secrets@5b44b387694dfa249cfa2dcf289ca871abe9e3e2 # v5.0.1
         with:
-          testing_ci_iam_user_access_key_id: ${{ needs.fetch-secrets.outputs.testing_ci_iam_user_access_key_id }}
-          testing_ci_iam_user_secret_access_key: ${{ needs.fetch-secrets.outputs.testing_ci_iam_user_secret_access_key }}
+          environment_management: ${{ needs.fetch-secrets.outputs.environment_management}}
           PASSPHRASE: ${{ secrets.PASSPHRASE }}
-          
+      - name: Set Account Number
+        run: |
+          ACCOUNT_NUMBER=$(jq -r -e '.account_ids["testing-test"]' <<< "$ENVIRONMENT_MANAGEMENT")
+          echo "::add-mask::$ACCOUNT_NUMBER"
+          echo ACCOUNT_NUMBER=$ACCOUNT_NUMBER >> $GITHUB_ENV
+
+      - name: Configure AWS credentials (OIDC)
+        uses: aws-actions/configure-aws-credentials@8df5847569e6427dd6c4fb1cf565c83acfa8afa7 # v6.0.0
+        with:
+          role-to-assume: arn:aws:iam::${{ env.ACCOUNT_NUMBER }}:role/RG-testing-ci-oidc
+          role-session-name: terratest-oidc
+          aws-region: eu-west-2
+
       - uses: actions/setup-go@4a3601121dd01d1626a1e23e37211e3254c1c06c # v6.4.0
         with:
           go-version: 1.26

--- a/.github/workflows/go-terratest.yml
+++ b/.github/workflows/go-terratest.yml
@@ -29,13 +29,6 @@ jobs:
     needs: fetch-secrets
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
-
-      # - name: Decrypt Secrets
-      #   uses: ministryofjustice/modernisation-platform-github-actions/decrypt-secrets@5b44b387694dfa249cfa2dcf289ca871abe9e3e2 # v5.0.1
-      #   with:
-      #     testing_ci_iam_user_access_key_id: ${{ needs.fetch-secrets.outputs.testing_ci_iam_user_access_key_id }}
-      #     testing_ci_iam_user_secret_access_key: ${{ needs.fetch-secrets.outputs.testing_ci_iam_user_secret_access_key }}
-      #     PASSPHRASE: ${{ secrets.PASSPHRASE }}
       
       - name: Decrypt Secrets
         uses: ministryofjustice/modernisation-platform-github-actions/decrypt-secrets@5b44b387694dfa249cfa2dcf289ca871abe9e3e2 # v5.0.1

--- a/main.tf
+++ b/main.tf
@@ -7,3 +7,9 @@ resource "aws_iam_openid_connect_provider" "github_actions" {
   url             = "https://token.actions.githubusercontent.com"
   tags            = var.tags_common
 }
+
+# Look up the existing OIDC provider when not creating one (e.g. it already exists in the account).
+data "aws_iam_openid_connect_provider" "github_actions" {
+  count = var.create_github_oidc_provider ? 0 : 1
+  url   = "https://token.actions.githubusercontent.com"
+}

--- a/outputs.tf
+++ b/outputs.tf
@@ -1,6 +1,6 @@
 output "github_actions_provider" {
   description = "This module configures an OIDC provider for use with GitHub actions"
-  value       = try(aws_iam_openid_connect_provider.github_actions[0].id, null)
+  value       = try(aws_iam_openid_connect_provider.github_actions[0].id, data.aws_iam_openid_connect_provider.github_actions[0].id, null)
 }
 
 output "github_actions_role" {

--- a/test/module_test.go
+++ b/test/module_test.go
@@ -9,7 +9,7 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
-func TestGitHubOIDCProviderCreation(t *testing.T) {
+func TestGitHubOIDCProvider(t *testing.T) {
 	t.Parallel()
 
 	terraformOptions := terraform.WithDefaultRetryableErrors(t, &terraform.Options{

--- a/test/unit-test/main.tf
+++ b/test/unit-test/main.tf
@@ -2,17 +2,14 @@ resource "random_id" "role" {
   byte_length = 1
 }
 
-resource "random_id" "role_without_provider" {
-  byte_length = 1
-}
-
 module "module_test" {
-  source                 = "../../"
-  additional_permissions = data.aws_iam_policy_document.extra_permissions.json
-  github_repositories    = ["ministryofjustice/modernisation-platform-environments:*", "ministryofjustice/modernisation-platform-ami-builds:*"]
-  role_name              = format("github-actions-%s", random_id.role.dec)
-  tags_common            = local.tags
-  tags_prefix            = terraform.workspace
+  source                      = "../../"
+  additional_permissions      = data.aws_iam_policy_document.extra_permissions.json
+  github_repositories         = ["ministryofjustice/modernisation-platform-environments:*", "ministryofjustice/modernisation-platform-ami-builds:*"]
+  role_name                   = format("github-actions-%s", random_id.role.dec)
+  tags_common                 = local.tags
+  tags_prefix                 = terraform.workspace
+  create_github_oidc_provider = false
 }
 
 #trivy:ignore:AVD-AWS-0345
@@ -40,37 +37,4 @@ data "aws_iam_policy_document" "extra_permissions" {
   }
 }
 
-module "module_test_without_provider" {
-  source                      = "../../"
-  additional_permissions      = data.aws_iam_policy_document.extra_permissions.json
-  github_repositories         = ["ministryofjustice/modernisation-platform-environments:*", "ministryofjustice/modernisation-platform-ami-builds:*"]
-  role_name                   = format("github-actions-%s", random_id.role_without_provider.dec)
-  tags_common                 = local.tags
-  tags_prefix                 = terraform.workspace
-  create_github_oidc_provider = false
-}
 
-#trivy:ignore:AVD-AWS-0345
-data "aws_iam_policy_document" "extra_permissions_without_provider" {
-  #checkov:skip=CKV_AWS_107
-  #checkov:skip=CKV_AWS_108
-  #checkov:skip=CKV_AWS_109
-  #checkov:skip=CKV_AWS_111
-  #checkov:skip=CKV_AWS_356 skipping check as this code is used in a unit test, not production
-  version = "2012-10-17"
-
-  statement {
-    effect = "Allow"
-    actions = [
-      "account:GetAlternateContact",
-      "cur:DescribeReportDefinitions",
-      "identitystore:ListGroups",
-      "secretsmanager:GetSecretValue",
-      "sts:AssumeRole",
-      "s3:*",
-      "kms:*",
-    ]
-
-    resources = ["*"]
-  }
-}

--- a/test/unit-test/outputs.tf
+++ b/test/unit-test/outputs.tf
@@ -9,13 +9,3 @@ output "oidc_role" {
   value = module.module_test.github_actions_role
 }
 
-output "github_actions_provider_without_provider" {
-  value = module.module_test_without_provider.github_actions_provider
-}
-
-output "github_actions_trust_policy_conditions_without_provider" {
-  value = jsondecode(module.module_test_without_provider.github_actions_role_trust_policy).Statement[*].Condition.StringLike
-}
-output "oidc_role_without_provider" {
-  value = module.module_test_without_provider.github_actions_role
-}


### PR DESCRIPTION
## Issue
https://github.com/ministryofjustice/modernisation-platform-security/issues/99

## Changes 
**GitHub Actions Workflow Improvements:**
- Updated `.github/workflows/go-terratest.yml` workflow to use OIDC authentication for AWS by configuring the `id-token: write` permission, extracting the account number from secrets, and setting up the AWS credentials using the new OIDC role `github-actions-testing`

**Existing OIDC Provider Handling:**
- `main.tf`, `outputs.tf`: Added a data source (`data.aws_iam_openid_connect_provider.github_actions`) to look up an existing OIDC provider when not creating one, and updated the output to return either the created or existing provider's ID. 

_This is needed as our new testing strategy relies on pre-existing OIDC provider for GH actions so we can no longer test the creation of a gh actions provider in `testing-test` without getting a duplication error. This does make the unit tests less useful but I believe the benefits of moving to using OIDC authentication vs use of static IAM credentials is worthwhile and we can consider alternative test options in future._

**Test and Output Simplification:**
- `test/unit-test/main.tf`, `test/unit-test/outputs.tf`: Removed redundant resources and modules related to provider-less scenarios, simplifying the test setup and outputs. 
- `test/module_test.go`: Renamed the test function for clarity to reflect the new provider handling logic.